### PR TITLE
Add proper trustedTesters support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ const got = require('got');
 const rootURI = 'https://www.googleapis.com';
 const refreshTokenURI = 'https://accounts.google.com/o/oauth2/token';
 const uploadExistingURI = id => `${rootURI}/upload/chromewebstore/v1.1/items/${id}`;
-const publishURI = (id, target) => (
-    `${rootURI}/chromewebstore/v1.1/items/${id}/publish?publishTarget=${target}`
-);
+const publishURI = id => `${rootURI}/chromewebstore/v1.1/items/${id}/publish`;
 
 const requiredFields = [
     'extensionId',
@@ -42,13 +40,17 @@ class APIClient {
         });
     }
 
-    publish(target = 'default', token) {
+    publish(target, token) {
         const { extensionId } = this;
         const eventualToken = token ? Promise.resolve(token) : this.fetchToken();
 
         return eventualToken.then(token => {
-            return got.post(publishURI(extensionId, target), {
+            return got.post(publishURI(extensionId), {
                 headers: this._headers(token),
+                body: target === 'trustedTesters' ? {
+					publish_to_trusted_testers: true,
+					target: 'trustedTesters'
+                } : {},
                 json: true
             }).then(this._extractBody);
         });


### PR DESCRIPTION
From: https://github.com/DrewML/chrome-webstore-upload-cli/pull/18#issuecomment-328518483

> For some reason the API seems to require an additional `publish_to_trusted_testers=true` parameter to the request, even if it's not documented anywhere [[1]](https://developer.chrome.com/webstore/webstore_api/items/publish#parameters) [[2]](https://developer.chrome.com/webstore/using_webstore_api). The module [chrome-extension-deploy](https://github.com/erikdesjardins/chrome-extension-deploy) seems to do this: 
> 
> https://github.com/erikdesjardins/chrome-extension-deploy/blob/68c3d48614f69f762e4a6d91f6cf157338b8192b/index.js#L82-L83

Edit: Don't delete the branch, it's currently being used in https://github.com/DrewML/chrome-webstore-upload-cli/pull/18