### PR TITLE
Update docs

### DIFF
--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -16,7 +16,7 @@ Here's how to get its 3 access keys: `clientId`, `clientSecret`, `refreshToken`
 0. Select on **External** and **Create**
 0. Only enter the Application name (e.g. `chrome-webstore-upload`) and **Save**
 
-	<img width="475" alt="Consent screen configuration" src="https://user-images.githubusercontent.com/1402241/77865809-82ff7d80-7230-11ea-8a96-e381d55524c5.png">
+	> <img width="475" alt="Consent screen configuration" src="https://user-images.githubusercontent.com/1402241/77865809-82ff7d80-7230-11ea-8a96-e381d55524c5.png">
 
 0. Visit https://console.developers.google.com/apis/library/chromewebstore.googleapis.com
 0. Click **Enable**
@@ -27,16 +27,16 @@ Here's how to get its 3 access keys: `clientId`, `clientSecret`, `refreshToken`
 
 0. Select **Other**, enter `chrome-webstore-upload` and click **Create** 
 
-    > <img width="187" alt="Configure client type" src="https://cloud.githubusercontent.com/assets/1402241/21517952/d1f36fce-cc97-11e6-92c0-de4485d97736.png">
+	> <img width="187" alt="Configure client type" src="https://cloud.githubusercontent.com/assets/1402241/21517952/d1f36fce-cc97-11e6-92c0-de4485d97736.png">
 
 0. Save your ✅ `clientId` and ✅ `clientSecret`, these are your 2 of your 3 keys.
 0. Place your `clientId` in this URL and open it:
 
-        https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob
+	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob`
 
 0. Follow its steps and warnings (this is your own peronal app) and wait on the last page:
 
-    > <img width="1021" alt="Last page of OAuth" src="https://user-images.githubusercontent.com/1402241/77866731-79781480-7234-11ea-8f81-c533846d89ea.png">
+	<img width="521" alt="Last page of OAuth" src="https://user-images.githubusercontent.com/1402241/77866731-79781480-7234-11ea-8f81-c533846d89ea.png">
 
 0. Run this in your browser console **on that last page**. It's a wizard to create your `refresh_token`:
 

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -4,48 +4,62 @@
 
 Here's how to get its 3 access keys: `clientId`, `clientSecret`, `refreshToken`
 
-*Note:* the names you enter here don't really matter.
+*Note:* the names you enter here don't really matter. This will take approximately 10 minutes, sorry.
 
-0. Visit https://console.developers.google.com/apis/credentials
+1. Visit https://console.developers.google.com/apis/credentials
 0. Create a project:
 
 	<img width="772" alt="Google APIs: Create project" src="https://user-images.githubusercontent.com/1402241/77865620-9a8a3680-722f-11ea-99cb-b09e5c0c11ec.png">
 
 0. Enter `chrome-webstore-upload` and **Create**
 0. Click on **Configure consent screen**
+0. Select on **External** and **Create**
 0. Only enter the Application name (e.g. `chrome-webstore-upload`) and **Save**
 
 	<img width="475" alt="Consent screen configuration" src="https://user-images.githubusercontent.com/1402241/77865809-82ff7d80-7230-11ea-8a96-e381d55524c5.png">
 
-0. Visit https://console.developers.google.com/apis/credentials again
+0. Visit https://console.developers.google.com/apis/library/chromewebstore.googleapis.com
+0. Click **Enable**
+0. Visit https://console.developers.google.com/apis/credentials
 0. Click **Create credentials** > **OAuth client ID**:
 
 	<img width="771" alt="Create credentials" src="https://user-images.githubusercontent.com/1402241/77865679-e89f3a00-722f-11ea-942d-5245091f22b8.png">
 
-0. Select **Other** 
+0. Select **Other**, enter `chrome-webstore-upload` and click **Create** 
 
     > <img width="187" alt="Configure client type" src="https://cloud.githubusercontent.com/assets/1402241/21517952/d1f36fce-cc97-11e6-92c0-de4485d97736.png">
 
-0. Enter a product name (e.g. `chrome-webstore-upload`) and click **Create** 
-
-0. Save your ✅ `clientId` and ✅ `clientSecret`, these are your keys.
+0. Save your ✅ `clientId` and ✅ `clientSecret`, these are your 2 of your 3 keys.
 0. Place your `clientId` in this URL and open it:
 
         https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob
 
-0. Follow its steps and copy the `authcode` it shows on the last page:
+0. Follow its steps and warnings (this is your own peronal app) and wait on the last page:
 
-    > <img width="400" alt="auth code" src="https://cloud.githubusercontent.com/assets/1402241/21518094/c3033bb0-cc98-11e6-82bb-f6c69ca103fe.png">
+    > <img width="1021" alt="Last page of OAuth" src="https://user-images.githubusercontent.com/1402241/77866731-79781480-7234-11ea-8f81-c533846d89ea.png">
 
-0. Run this in your browser console.  
-It's a wizard to create and copy a `curl` into your clipboard:
+0. Run this in your browser console **on that last page**. It's a wizard to create your `refresh_token`:
 
-        copy(`curl "https://accounts.google.com/o/oauth2/token" -d "client_id=${encodeURIComponent(prompt('Enter your clientId'))}&client_secret=${encodeURIComponent(prompt('Enter your clientSecret'))}&code=${encodeURIComponent(prompt('Enter your authcode'))}&grant_type=authorization_code&redirect_uri=urn:ietf:wg:oauth:2.0:oob"`);alert('The curl has been copied. Paste it into your terminal.')
+```js
+response = await fetch('https://accounts.google.com/o/oauth2/token', {
+  method: "POST",
+  body: new URLSearchParams([
+    ['client_id', prompt('Enter your clientId')],
+    ['client_secret', prompt('Enter your clientSecret')],
+    ['code', new URLSearchParams(location.search).get('approvalCode')],
+    ['grant_type', 'authorization_code'],
+    ['redirect_uri', 'urn:ietf:wg:oauth:2.0:oob']
+  ]),
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded'
+  }
+});
+json = await response.json();
+console.log(json);
+if (!json.error) {
+  copy(json.refresh_token);
+  alert('The refresh_token has been copied into your clipboard. You’re done!');
+}
+```
 
-
-0. Paste the generated code in your terminal and run it.
-0. Save your ✅ `refreshToken`:
-
-    <img width="400" alt="access token" src="https://cloud.githubusercontent.com/assets/1402241/21518331/9b7e3b42-cc9a-11e6-8d65-cde5ba5ea105.png">
-
-0. Done. Now you should have ✅ `clientId`, ✅ `clientSecret` and ✅ `refreshToken`. You can use these for all your extensions, but don't share them!
+9001. Done. Now you should have ✅ `clientId`, ✅ `clientSecret` and ✅ `refreshToken`. You can use these for all your extensions, but don't share them!

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -6,28 +6,27 @@ Here's how to get its 3 access keys: `clientId`, `clientSecret`, `refreshToken`
 
 *Note:* the names you enter here don't really matter.
 
-0. Visit https://console.developers.google.com/apis/api/chromewebstore.googleapis.com/overview
+0. Visit https://console.developers.google.com/apis/credentials
 0. Create a project:
 
-    <img width="296" alt="chrome-apis-create-project" src="https://cloud.githubusercontent.com/assets/1402241/21517725/55e5c626-cc96-11e6-9b55-ec9c80e10ec4.png">
-0. Enter a name (e.g. `webstore-yourextensionname`)
-0. Visit https://console.developers.google.com/apis/api/chromewebstore.googleapis.com/overview again
-0. Enable the API:
+	<img width="772" alt="Google APIs: Create project" src="https://user-images.githubusercontent.com/1402241/77865620-9a8a3680-722f-11ea-99cb-b09e5c0c11ec.png">
 
-    <img width="400" alt="chrome-apis-enable-webstore" src="https://cloud.githubusercontent.com/assets/1402241/21517842/2a9f36a4-cc97-11e6-8ffa-ad49ac2ca3ce.png">
+0. Enter `chrome-webstore-upload` and **Create**
+0. Click on **Configure consent screen**
+0. Only enter the Application name (e.g. `chrome-webstore-upload`) and **Save**
 
-0. Open **Credentials** > **Create credentials** > **OAuth client ID**:
+	<img width="475" alt="Consent screen configuration" src="https://user-images.githubusercontent.com/1402241/77865809-82ff7d80-7230-11ea-8a96-e381d55524c5.png">
 
-    <img width="400" alt="create-credentials" src="https://cloud.githubusercontent.com/assets/1402241/21517881/64f727f8-cc97-11e6-9c6b-b347b71352bf.png">
+0. Visit https://console.developers.google.com/apis/credentials again
+0. Click **Create credentials** > **OAuth client ID**:
 
-0. Click on **Configure consent screen**:
+	<img width="771" alt="Create credentials" src="https://user-images.githubusercontent.com/1402241/77865679-e89f3a00-722f-11ea-942d-5245091f22b8.png">
 
-    > <img width="400" alt="configure consent screen" src="https://cloud.githubusercontent.com/assets/1402241/21517907/92640e0e-cc97-11e6-93f7-d077664eead9.png">
+0. Select **Other** 
 
-0. Enter a product name (e.g. `yourextensionname`) and save
-0. Select **Other** and click **Create** 
+    > <img width="187" alt="Configure client type" src="https://cloud.githubusercontent.com/assets/1402241/21517952/d1f36fce-cc97-11e6-92c0-de4485d97736.png">
 
-    > <img width="187" alt="client type id" src="https://cloud.githubusercontent.com/assets/1402241/21517952/d1f36fce-cc97-11e6-92c0-de4485d97736.png">
+0. Enter a product name (e.g. `chrome-webstore-upload`) and click **Create** 
 
 0. Save your ✅ `clientId` and ✅ `clientSecret`, these are your keys.
 0. Place your `clientId` in this URL and open it:


### PR DESCRIPTION
Closes #31 
Closes #17 The step is now easier

Google made it even longer. Niiiice.

I'll double-check this from scratch soon. 

Preview it at https://github.com/DrewML/chrome-webstore-upload/blob/update-docs/How%20to%20generate%20Google%20API%20keys.md