### PR TITLE
remove unsupported json param from uploadExisting

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,7 @@ class APIClient {
         return eventualToken.then(token => {
             return got.put(uploadExistingURI(extensionId), {
                 headers: this._headers(token),
-                body: readStream,
-                json: true
+                body: readStream
             }).then(this._extractBody);
         });
     }


### PR DESCRIPTION
As I had an issue with uploads failing (which eventually turned out to be an invalid refresh token), I used the latest commit (2f20c7dde2b52aa732bf58a30abd8e423a711fd3) of the project, to test whether my issue had been fixed. If I tried to upload my extensiont, the got  module would throw an error though `TypeError: The `body` option must be an Object or Array when the `json` option is used`

Referring to it's documentation the json param is invalid here. Therefore removed it and upload does work now fine again.

see https://github.com/sindresorhus/got#body
> Note #1: The body option cannot be used with the json or form option.