### PR TITLE
Update `How to generate Google API keys` wizard

### DIFF
--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -57,8 +57,13 @@ response = await fetch('https://accounts.google.com/o/oauth2/token', {
 json = await response.json();
 console.log(json);
 if (!json.error) {
-  copy(json.refresh_token);
-  alert('The refresh_token has been copied into your clipboard. You’re done!');
+  if (copy) {
+    copy(json.refresh_token);
+    alert('The refresh_token has been copied into your clipboard. You’re done!');
+  } else {
+    console.log('Copy your token:', json.refresh_token);
+    alert('Copy your refresh_token from the console output.')
+  }
 }
 ```
 

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -62,7 +62,7 @@ if (!json.error) {
     alert('The refresh_token has been copied into your clipboard. You’re done!');
   } else {
     console.log('Copy your token:', json.refresh_token);
-    alert('Copy your refresh_token from the console output.')
+    alert('Copy your refresh_token from the console output. You’re done!');
   }
 }
 ```


### PR DESCRIPTION
I followed the tutorial but I got the following error during the last step:

As you can see in the screenshot the copy function is indeed there but i suppose because the script is calling it chrome prevents it.
This happened in Chrome 85.0.4183.121 in Incognito Mode.

![image](https://user-images.githubusercontent.com/14973744/95082920-1227a980-071c-11eb-80fd-988a72327874.png)
