### PR TITLE
Allow empty string options in constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const requiredFields = [
 class APIClient {
     constructor(options) {
         requiredFields.forEach(field => {
-            if (!options[field]) {
+            if (typeof options[field] !== 'string' && !options[field]) {
                 throw new Error(`Option "${field}" is required`);
             }
 


### PR DESCRIPTION
Hi @DrewML, I have a proposal, great lib btw :)

## Why
The current status of the Chrome API doesn't require a `clientSecret` ([proof](https://stackoverflow.com/a/36620574/6672428)), so we should allow cases like
```js
const webStore = require('chrome-webstore-upload')({
    extensionId: 'ecnglinljpjkbgmdpeiglonddahpbkeb',
    clientId: 'xxxxxxxxxx',
    clientSecret: '',
    refreshToken: 'xxxxxxxxxx' 
});
```

## What this PR does
Stricter check for `undefined` or `null` value of options.