### PR TITLE
Skip subdirectories when zipping a source directory

### DIFF
--- a/source/zip-dir.ts
+++ b/source/zip-dir.ts
@@ -7,19 +7,16 @@ export default async function zipStreamFromDirectory(directory: string): Promise
     const entries = await readdir(directory, { recursive: true, withFileTypes: true });
     const files = entries
         .filter(entry => entry.isFile() && isNotJunk(entry.name))
-        .map(entry => ({
-            absolute: join(entry.parentPath, entry.name),
-            relative: relative(directory, join(entry.parentPath, entry.name)),
-        }));
+        .map(entry => relative(directory, join(entry.parentPath, entry.name)));
 
-    if (!files.some(file => file.relative === 'manifest.json')) {
+    if (!files.includes('manifest.json')) {
         throw new Error(`manifest.json was not found in ${directory}`);
     }
 
     const zip = new yazl.ZipFile();
 
     for (const file of files) {
-        zip.addFile(file.absolute, file.relative);
+        zip.addFile(join(directory, file), file);
     }
 
     zip.end();

--- a/source/zip-dir.ts
+++ b/source/zip-dir.ts
@@ -1,24 +1,28 @@
 import { readdir } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { join, relative } from 'node:path';
 import { isNotJunk } from 'junk';
 import yazl from 'yazl';
 
 export default async function zipStreamFromDirectory(directory: string): Promise<NodeJS.ReadableStream> {
-    const allFiles = await readdir(directory, { recursive: true });
-    const files = allFiles.filter(file => isNotJunk(basename(file)));
+    const entries = await readdir(directory, { recursive: true, withFileTypes: true });
+    const files = entries
+        .filter(entry => entry.isFile() && isNotJunk(entry.name))
+        .map(entry => ({
+            absolute: join(entry.parentPath, entry.name),
+            relative: relative(directory, join(entry.parentPath, entry.name)),
+        }));
 
-    if (!files.includes('manifest.json')) {
+    if (!files.some(file => file.relative === 'manifest.json')) {
         throw new Error(`manifest.json was not found in ${directory}`);
     }
 
     const zip = new yazl.ZipFile();
 
     for (const file of files) {
-        zip.addFile(join(directory, file), file);
+        zip.addFile(file.absolute, file.relative);
     }
 
     zip.end();
 
     return zip.outputStream;
 }
-

--- a/test/fixtures/valid-extension/subfolder/file.txt
+++ b/test/fixtures/valid-extension/subfolder/file.txt
@@ -1,0 +1,1 @@
+test fixture file inside a subdirectory

--- a/test/zip-dir.test.js
+++ b/test/zip-dir.test.js
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { Readable } from 'node:stream';
 import { test, expect } from 'vitest';
 import zipStreamFromDirectory from '../source/zip-dir.js';
@@ -13,6 +14,17 @@ test('Rejects when manifest.json is not found', async () => {
 test('Returns a readable stream for valid extension directory', async () => {
     const stream = await zipStreamFromDirectory('./test/fixtures/valid-extension');
     expect(stream).toBeInstanceOf(Readable);
+});
+
+test('Produces a complete zip stream for an extension with subdirectories', async () => {
+    const stream = await zipStreamFromDirectory('./test/fixtures/valid-extension');
+    const chunks = [];
+    await new Promise((resolve, reject) => {
+        stream.on('data', chunk => chunks.push(chunk));
+        stream.on('end', resolve);
+        stream.on('error', reject);
+    });
+    expect(Buffer.concat(chunks).length).toBeGreaterThan(0);
 });
 
 test('Can accept test/extension directory', async () => {


### PR DESCRIPTION
Hi Fregante, first of all thank you for your package! I did not find contribution guidelines so I hope this adheres to your standards. Let me know if you require me to change anything.

### Problem

`zipStreamFromDirectory` crashes when the source directory contains subdirectories — most real-world extensions have at least one (e.g. `_locales/`, an assets folder, etc.).

```
Error: not a file: <directory>/<subdir>
    at node_modules/yazl/index.js:37:52
```

`fs.readdir(dir, { recursive: true })` returns directory entries alongside files. They were passed to `yazl.addFile`, which rejects anything that isn't a regular file. The bug went unnoticed because:

1. The test fixtures (`test/extension`, `test/fixtures/valid-extension`) were flat — no subdirectories.
2. `zip-dir.test.js` only asserted `instanceof Readable` and never consumed the stream, so the asynchronous yazl error never surfaced during tests.

### Fix

- Use `readdir(..., { withFileTypes: true })` and filter on `entry.isFile()` so directories are skipped before being handed to yazl.

### Test changes

- Added `test/fixtures/valid-extension/subfolder/file.txt` so the fixture exercises subdirectories.
- Added a new test `Produces a complete zip stream for an extension with subdirectories` that consumes the stream end-to-end. Without the fix it fails with the original `Error: not a file:` error; with the fix it passes.

`npm test` (xo + vitest + tsc) passes locally.
